### PR TITLE
Treat config.json ajax output as JSON instead of string

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,6 +1,6 @@
   jQuery( document ).ready(function( $ ) {
 
-    $.ajax( { url: 'config.json' } ).done(  function( config ) {
+    $.ajax( { url: 'config.json', dataType: 'json' } ).done(  function( config ) {
 
     var c = config;
 


### PR DESCRIPTION
On servers that output json without the proper `application/json` header, the `api-console` will not work properly. It will fail at the following line to query `api_url` because `config` is a string rather than an evaluated JS object:

```
$.ajax( { url: config.api_url + "/" } ).done( function( response ) {
```

This fix forces `api-console` to treat the `config.json` as a `json` dataType.
