### PR TITLE
Update documentation about creating an API consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ of your screen. (If these are missing, your `api_url` is set incorrectly.)
 To make authenticated requests, simply hit the **Auth** button and follow the
 steps on-screen!
 
+**NOTE** - The API console does not protect against someone reading the secrets
+in your `config.json` from a web browser or other HTTP client!  Be sure to
+secure your installation by requiring authentication through your web server.
+
 ## Credits
 * Uses code based on OpenStreetMap's [osm-auth][]. Licensed under the public
   domain.

--- a/README.md
+++ b/README.md
@@ -10,16 +10,11 @@ Once you have WP API and the OAuth server plugins activated on your server,
 you'll need to create a "consumer". This is an identifier for the application,
 and includes a "key" and "secret", both needed to link to your site.
 
-To create the consumer, run the following **on your server**:
-```bash
-$ wp oauth1 add
+Go to **Applications** > **Users** and add your application there.  Be sure to
+specify the callback URL as the path to the console's `land.html` page!
 
-ID: 4
-Key: sDc51JgH2mFu
-Secret: LnUdIsyhPFnURkatekRIAUfYV7nmP4iF3AVxkS5PRHPXxgOW
-```
-
-Note the key and secret returned here. You'll need those in a moment.
+Note the key and secret returned when you add the application. You'll need
+those in a moment.
 
 ### Step 2: Save your configuration
 Time to link the console to your site. Copy `config.sample.json` to


### PR DESCRIPTION
It looks like the old method of `wp oauth1 add` is no longer supported since you can't add a callback URL this way.  If that makes sense, then this PR fixes #13.

Also add a note about security of the secrets in the `config.json` file.
